### PR TITLE
:question: Allow pharmacies without opening times

### DIFF
--- a/app/middleware/gp.js
+++ b/app/middleware/gp.js
@@ -74,11 +74,17 @@ function getPharmacyOpeningTimes(req, res, next) {
       (syndicationXml) => {
         const now = new Date();
         const dayOfWeek = dateUtils.getDayName(now);
-        /* eslint-disable no-param-reassign */
-        pharmacy.openingTimes = openingTimesParser('general', syndicationXml);
-        pharmacy.openingTimes.today = pharmacy.openingTimes[dayOfWeek].times;
-        pharmacy.openNow = dateUtils.isOpen(now, pharmacy.openingTimes.today);
-        /* eslint-enable no-param-reassign */
+        try {
+          /* eslint-disable no-param-reassign */
+          pharmacy.openingTimes = openingTimesParser('general', syndicationXml);
+          pharmacy.openingTimes.today = pharmacy.openingTimes[dayOfWeek].times;
+          pharmacy.openNow = dateUtils.isOpen(now, pharmacy.openingTimes.today);
+          /* eslint-enable no-param-reassign */
+        } catch (e) {
+          // intentionally left empty to allow pharmacies without any opening time
+          // to be displayed without crashing the app
+          console.log(e);
+        }
       },
       () => {
         pharmacyCount--;

--- a/app/views/results.nunjucks
+++ b/app/views/results.nunjucks
@@ -17,10 +17,14 @@
         </tr>
         <tr>
           <td></td>
-          {% if pharmacy.openNow %}
-            <td><p><strong>Currently open.</strong><br>Open today from {{ pharmacy.openingTimes["today"][0].fromTime }} to {{ pharmacy.openingTimes["today"][0].toTime }}</p></td>
+          {% if pharmacy.openingTimes %}
+            {% if pharmacy.openNow %}
+              <td><p><strong>Currently open.</strong><br>Open today from {{ pharmacy.openingTimes["today"][0].fromTime }} to {{ pharmacy.openingTimes["today"][0].toTime }}</p></td>
+            {% else %}
+              <td><p><strong>Currently closed</strong><br>Next open at ...</p></td>
+            {% endif %}
           {% else %}
-            <td><p><strong>Currently closed</strong><br>Next open at ...</p></td>
+              <td><p><strong>Opening times not known.</strong></p></td>
           {% endif %}
           <td><p>
             <a href="http://maps.google.co.uk/maps?z=12&t=m&q=loc:{{pharmacy.content.organisationSummary.geographicCoordinates.latitude}}+{{pharmacy.content.organisationSummary.geographicCoordinates.longitude}}" class="button button-secondary-cta" target="_blank">Get directions</a></p></td>
@@ -44,22 +48,23 @@
                 Telephone {{ pharmacy.content.organisationSummary.contact.telephone }}
                 </p>
 
-                <p><strong>Opening times</strong></p>
-
-                <table class="gpOpeningTimes">
-                  <tbody>
-                    {% for day in daysOfTheWeek %}
-                      <tr>
-                        <td>{{day | capitalize }}</td>
-                        {% if pharmacy.openingTimes[day].times[0] != 'Closed' %}
-                          <td>{{ pharmacy.openingTimes[day].times[0].fromTime }} to {{ pharmacy.openingTimes[day].times[0].toTime }}</td>
-                        {% else %}
-                          <td>Closed</td>
-                        {% endif %}
-                      </tr>
-                    {% endfor %}
-                  </tbody>
-                </table>
+                {% if pharmacy.openingTimes %}
+                  <p><strong>Opening times</strong></p>
+                  <table class="gpOpeningTimes">
+                    <tbody>
+                      {% for day in daysOfTheWeek %}
+                        <tr>
+                          <td>{{day | capitalize }}</td>
+                          {% if pharmacy.openingTimes[day].times[0] != 'Closed' %}
+                            <td>{{ pharmacy.openingTimes[day].times[0].fromTime }} to {{ pharmacy.openingTimes[day].times[0].toTime }}</td>
+                          {% else %}
+                            <td>Closed</td>
+                          {% endif %}
+                        </tr>
+                      {% endfor %}
+                    </tbody>
+                  </table>
+                {% endif %}
               </div>
             </details>
           </td>


### PR DESCRIPTION
Missing opening times were causeing the app to crash.

Issue: #4 