### PR TITLE
:stars: Use local logo always

### DIFF
--- a/public/css/beta-style.css
+++ b/public/css/beta-style.css
@@ -14,3 +14,7 @@
     padding: 9px 30px 15px 30px;
   }
 }
+
+.global-header--link {
+  background-image: url("../images/logotype-nhs-colour.png");
+}


### PR DESCRIPTION
Prevents the logo reverting back to the beta version when the styles are updated.