### PR TITLE
:lock_with_ink_pen: Prevent map button text wrapping

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -2892,6 +2892,7 @@ a.another-gp-black:after {
 
 .map-button {
   font-size: 1.3rem;
+  white-space: nowrap;
 }
 
 .global-header--link {


### PR DESCRIPTION
Fixes #105